### PR TITLE
Test suite integration for Eliot logs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,15 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     install_requires=[
-        "incremental", "twisted[tls]",
+        "incremental",
+        "twisted[tls]",
     ],
     extras_require={
         "dev": [
             "treq",
+            "testtools",
+            "eliot",
+            "eliot-tree",
         ],
     },
 )

--- a/src/txkube/testing/_eliot.py
+++ b/src/txkube/testing/_eliot.py
@@ -1,0 +1,64 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+from io import BytesIO
+
+from fixtures import Fixture
+
+from eliot import add_destination
+from eliottree import Tree, render_task_nodes
+
+from testtools.content import Content
+from testtools.content_type import UTF8_TEXT
+
+
+def _eliottree(logs):
+    """
+    Render some Eliot log events into a tree-like string.
+
+    :param list[dict] logs: The Eliot log events to render.  These should be
+        dicts like those passed to an Eliot destination.
+
+    :return bytes: The rendered string.
+    """
+    tree = Tree()
+    tree.merge_tasks(logs)
+    nodes = tree.nodes()
+
+    out = BytesIO()
+    render_task_nodes(
+        write=out.write,
+        nodes=nodes,
+        field_limit=0,
+    )
+    return out.getvalue()
+
+
+class CaptureEliotLogs(Fixture):
+    """
+    A fixture which captures Eliot logs emitted while it is active and adds a
+    detail which includes the (easily human-readable) "tree" rendering of
+    those logs.
+    """
+    LOG_DETAIL_NAME = "eliot-log"
+
+    # Unusually, the Fixtures convention is that underscore prefixed methods
+    # are not private.  Instead, they're more like internal hooks.  It is
+    # intended that application code override these methods you might
+    # otherwise expect are private.
+    def _setUp(self):
+        self.logs = []
+        add_destination(self.logs.append)
+        self.addDetail(
+            self.LOG_DETAIL_NAME,
+            Content(
+                UTF8_TEXT,
+                # Safeguard the logs against _tearDown.  Capture the list
+                # object in the lambda's defaults.
+                lambda logs=self.logs: [_eliottree(logs)],
+            ),
+        )
+
+
+    def _tearDown(self):
+        remove_destination(self.logs.append)


### PR DESCRIPTION
Fixes #3 

When used, this will cause failed tests to report a tree of Eliot events logged during those tests.  Something like:

```
[FAIL]
Traceback (most recent call last):
Failure: testtools.testresult.real._StringException: eliot-log: {{{
551abdef-6173-4952-b28f-45753d4ddbd7
+-- network-client:post@1/started
    `-- timestamp: 1484755226.504377
    +-- network-client:post@2/succeeded
        `-- timestamp: 1484755226.531424

ff65a486-9856-49e6-a3df-87660cc276e8
+-- network-client:post@1/started
    `-- timestamp: 1484755226.534191
    +-- network-client:post@2/succeeded
        `-- timestamp: 1484755226.56101
}}}
```