### PR TITLE
Updated README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Once running::
   $ TXKUBE_INTEGRATION_CONTEXT=minikube trial txkube
 
 This will run the full test suite which includes the integration tests.
-It will interact with (and *make destructive changes to*) the named Kubernetes cluster.
+It will interact with (and *make destructive changes to*) the identified Kubernetes cluster.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,17 @@ After installing the development dependencies, you can run the test suite with t
   $ pip install txkube[dev]
   $ trial txkube
 
+txkube also includes integration tests.
+It is **not** recommended that you run these against anything but a dedicated *testing* Kubernetes cluster.
+`Minikube`_ is an easy way to obtain such a thing.
+Once running::
+
+  $ pip install txkube[dev]
+  $ TXKUBE_INTEGRATION_CLUSTER_NAME=minikube trial txkube
+
+This will run the full test suite which includes the integration tests.
+It will interact with (and *make destructive changes to*) the named Kubernetes cluster.
+
 License
 -------
 
@@ -73,3 +84,4 @@ See the LICENSE file for more details.
 
 
 .. _Kubernetes: https://kubernetes.io/
+.. _Minikube: https://kubernetes.io/docs/getting-started-guides/minikube/

--- a/README.rst
+++ b/README.rst
@@ -24,23 +24,15 @@ Usage Sample
 .. code-block:: python
 
    from __future__ import print_function
-   from os import environ
    from twisted.internet.task import react
-   from twisted.python.url import URL
 
-   from txkube import Namespace, network_kubernetes, authenticate_with_serviceaccount
+   from txkube import v1, network_kubernetes_from_context
 
    @react
    def main(reactor):
-       agent = authenticate_with_serviceaccount(reactor)
-       base_url = URL(
-           scheme=u"https",
-           host=environ["KUBERNETES_SERVICE_HOST"].decode("ascii"),
-           port=int(environ["KUBERNETES_SERVICE_PORT"]),
-       )
-       k8s = network_kubernetes(base_url=base_url, agent=agent)
+       k8s = network_kubernetes_from_context(reactor, u"minikube")
        client = k8s.client()
-       d = client.list(Namespace)
+       d = client.list(v1.Namespace)
        d.addCallback(print)
        return d
 

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,14 @@ Usage Sample
 
    from __future__ import print_function
    from twisted.internet.task import react
-   from txkube import network_kubernetes
+   from txkube import ConfigMap, network_kubernetes
 
    @react
    def main(reactor):
-       k8s = network_kubernetes(base_url=URL.fromText(u"https://kubernetes/"))
+       agent = authenticate_with_serviceaccount(reactor)
+       k8s = network_kubernetes(base_url=URL.fromText(u"https://kubernetes/"), agent=agent)
        client = k8s.client()
-       d = client.list_deployments()
+       d = client.list(ConfigMap)
        d.addCallback(print)
        return d
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ It is **not** recommended that you run these against anything but a dedicated *t
 Once running::
 
   $ pip install txkube[dev]
-  $ TXKUBE_INTEGRATION_CLUSTER_NAME=minikube trial txkube
+  $ TXKUBE_INTEGRATION_CONTEXT=minikube trial txkube
 
 This will run the full test suite which includes the integration tests.
 It will interact with (and *make destructive changes to*) the named Kubernetes cluster.

--- a/README.rst
+++ b/README.rst
@@ -24,15 +24,23 @@ Usage Sample
 .. code-block:: python
 
    from __future__ import print_function
+   from os import environ
    from twisted.internet.task import react
-   from txkube import ConfigMap, network_kubernetes
+   from twisted.python.url import URL
+
+   from txkube import Namespace, network_kubernetes, authenticate_with_serviceaccount
 
    @react
    def main(reactor):
        agent = authenticate_with_serviceaccount(reactor)
-       k8s = network_kubernetes(base_url=URL.fromText(u"https://kubernetes/"), agent=agent)
+       base_url = URL(
+           scheme=u"https",
+           host=environ["KUBERNETES_SERVICE_HOST"].decode("ascii"),
+           port=int(environ["KUBERNETES_SERVICE_PORT"]),
+       )
+       k8s = network_kubernetes(base_url=base_url, agent=agent)
        client = k8s.client()
-       d = client.list(ConfigMap)
+       d = client.list(Namespace)
        d.addCallback(print)
        return d
 


### PR DESCRIPTION
Fixes #35 

This has no automated tests but it works against a minikube:

```
$ kubectl run txkube --rm --attach --image exarkun/txkube:6 --restart=Never                                                                                    
Waiting for pod default/txkube to be running, status is Pending, pod ready: false
ObjectCollection(items=_CheckedIObjectPVector([Namespace(status=NamespaceStatus(phase=u'Active'), metadata=ObjectMeta(ownerReferences=V1.ownerreferencePVector([]), name=u'default', clusterName=None, deletionGrac
ePeriodSeconds=None, labels=UnicodeToUnicodePMap({}), namespace=None, generation=None, finalizers=UnicodePVector([]), resourceVersion=u'11', generateName=None, creationTimestamp=datetime.datetime(2017, 1, 28, 14
, 15, 47, tzinfo=tzlocal()), annotations=UnicodeToUnicodePMap({}), selfLink=u'/api/v1/namespacesdefault', uid=u'43b4707c-e564-11e6-bb70-08002726a725')), Namespace(status=NamespaceStatus(phase=u'Active'), metadat
a=ObjectMeta(ownerReferences=V1.ownerreferencePVector([]), name=u'kube-system', clusterName=None, deletionGracePeriodSeconds=None, labels=UnicodeToUnicodePMap({}), namespace=None, generation=None, finalizers=Uni
codePVector([]), resourceVersion=u'134', generateName=None, creationTimestamp=datetime.datetime(2017, 1, 28, 14, 15, 47, tzinfo=tzlocal()), annotations=UnicodeToUnicodePMap({u'kubectl.kubernetes.io/last-applied-
configuration': u'{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kube-system","creationTimestamp":null},"spec":{},"status":{}}'}), selfLink=u'/api/v1/namespaceskube-system', uid=u'43ce1fc8-e564-11e6-b
b70-08002726a725'))]))
```
