### PR TITLE
A different approach to fixing codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,18 @@
+# See http://coverage.readthedocs.io/en/coverage-4.3.4/config.html#run
 [run]
+# We want branch coverage measurement (we want as much measurement as possible).
 branch = True
+
+# This identifies the packages for which to measure coverage.
 source = txkube
+
+# See http://coverage.readthedocs.io/en/coverage-4.3.4/config.html#paths
+[paths]
+
+# Together with a call to `coverage combine .coverage` this causes txkube's
+# source files to appear as "src/txkube" in the coverage report.  This is not
+# only nicer for a person to look at, it makes codecov happier (because
+# src/txkube/... are the paths *it* sees for our source code).
+source =
+       src/txkube
+       /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/txkube

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 branch = True
-include = */txkube/*
+source = txkube

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
 script:
   - "pyflakes src"
   - "coverage run --rcfile=${PWD}/.coveragerc $(type -p trial) txkube"
+  # See .coveragerc for an explanation of this step.
+  - "coverage combine .coverage"
 
 after_success:
   - "codecov"


### PR DESCRIPTION
This attempts to generate nice `src/txkube/...` paths in the coverage report.
