### PR TITLE
Switch NamespaceStatus, Namespace, and ConfigMap to Swagger

### DIFF
--- a/src/txkube/__init__.py
+++ b/src/txkube/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "v1",
     "ObjectMeta",
     "object_from_raw",
-    "Namespace", "ConfigMap",
+    "ConfigMap",
     "ObjectCollection",
 
     "network_kubernetes", "memory_kubernetes",
@@ -31,7 +31,7 @@ from ._interface import IObject, IObjectLoader, IKubernetes, IKubernetesClient
 from ._model import (
     v1,
     object_from_raw,
-    Namespace, ConfigMap,
+    ConfigMap,
     ObjectCollection,
 )
 

--- a/src/txkube/__init__.py
+++ b/src/txkube/__init__.py
@@ -11,9 +11,7 @@ __all__ = [
     "network_client", "memory_client",
 
     "v1",
-    "ObjectMeta",
     "object_from_raw",
-    "ConfigMap",
     "ObjectCollection",
 
     "network_kubernetes", "memory_kubernetes",
@@ -31,7 +29,6 @@ from ._interface import IObject, IObjectLoader, IKubernetes, IKubernetesClient
 from ._model import (
     v1,
     object_from_raw,
-    ConfigMap,
     ObjectCollection,
 )
 

--- a/src/txkube/__init__.py
+++ b/src/txkube/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
     "network_client", "memory_client",
 
     "v1",
-    "NamespaceStatus",
     "ObjectMeta",
     "object_from_raw",
     "Namespace", "ConfigMap",
@@ -31,7 +30,6 @@ from ._interface import IObject, IObjectLoader, IKubernetes, IKubernetesClient
 
 from ._model import (
     v1,
-    NamespaceStatus,
     object_from_raw,
     Namespace, ConfigMap,
     ObjectCollection,

--- a/src/txkube/_memory.py
+++ b/src/txkube/_memory.py
@@ -25,7 +25,7 @@ from treq.testing import RequestTraversalAgent
 
 from . import (
     IKubernetes, network_kubernetes,
-    v1, ObjectCollection, ConfigMap,
+    v1, ObjectCollection,
 )
 
 
@@ -192,4 +192,4 @@ class _Kubernetes(object):
             """
             Create a new ConfigMap.
             """
-            return self._create(request, ConfigMap, self.state.configmaps, "configmaps")
+            return self._create(request, v1.ConfigMap, self.state.configmaps, "configmaps")

--- a/src/txkube/_memory.py
+++ b/src/txkube/_memory.py
@@ -25,7 +25,7 @@ from treq.testing import RequestTraversalAgent
 
 from . import (
     IKubernetes, network_kubernetes,
-    v1, ObjectCollection, Namespace, ConfigMap,
+    v1, ObjectCollection, ConfigMap,
 )
 
 
@@ -171,7 +171,7 @@ class _Kubernetes(object):
             """
             Create a new Namespace.
             """
-            return self._create(request, Namespace, self.state.namespaces, "namespaces")
+            return self._create(request, v1.Namespace, self.state.namespaces, "namespaces")
 
         @app.route(u"/configmaps", methods=[u"GET"])
         def list_configmaps(self, request, namespace=None):

--- a/src/txkube/_memory.py
+++ b/src/txkube/_memory.py
@@ -25,8 +25,7 @@ from treq.testing import RequestTraversalAgent
 
 from . import (
     IKubernetes, network_kubernetes,
-    NamespaceStatus,
-    ObjectCollection, Namespace, ConfigMap,
+    v1, ObjectCollection, Namespace, ConfigMap,
 )
 
 
@@ -81,7 +80,7 @@ class _KubernetesState(object):
 def terminate(obj):
     # TODO: Add deletionTimestamp?  See #24
     return obj.transform(
-        [u"status"], NamespaceStatus.terminating(),
+        [u"status"], v1.NamespaceStatus.terminating(),
     )
 
 

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -50,20 +50,11 @@ v1.NamespaceStatus = NamespaceStatus
 
 @provider(IObjectLoader)
 @implementer(IObject)
-class Namespace(PClass):
+class Namespace(v1.Namespace):
     """
     ``Namespace`` instances model `Kubernetes namespaces
     <https://kubernetes.io/docs/user-guide/namespaces/>`_.
     """
-    kind = u"Namespace"
-
-    metadata = field(
-        mandatory=True,
-        invariant=instance_of(v1.ObjectMeta),
-    )
-
-    status = field(mandatory=True, type=(NamespaceStatus, type(None)))
-
     @classmethod
     def default(cls):
         """
@@ -118,6 +109,7 @@ class Namespace(PClass):
             result[u"status"] = self.status.to_raw()
         return result
 
+v1.Namespace = Namespace
 
 
 @provider(IObjectLoader)

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -21,13 +21,11 @@ from ._swagger import Swagger, VersionedPClasses
 spec = Swagger.from_path(FilePath(__file__).sibling(u"kubernetes-1.5.json"))
 v1 = VersionedPClasses(spec, u"v1", name_field=u"kind", version_field=u"apiVersion")
 
-class NamespaceStatus(PClass):
+class NamespaceStatus(v1.NamespaceStatus):
     """
     ``NamespaceStatus`` instances model `Kubernetes namespace status
     <https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_namespacestatus>`_.
     """
-    phase = field(mandatory=True)
-
     @classmethod
     def active(cls):
         return cls(phase=u"Active")
@@ -44,7 +42,7 @@ class NamespaceStatus(PClass):
 
 
     def to_raw(self):
-        return {u"phase": self.phase}
+        return self.serialize()
 
 
 

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -10,12 +10,12 @@ from uuid import uuid4
 
 from zope.interface import provider, implementer
 
-from pyrsistent import CheckedPVector, PClass, field, pmap_field, thaw
+from pyrsistent import CheckedPVector, PClass, field, thaw
 
 from twisted.python.filepath import FilePath
 
 from . import IObject, IObjectLoader
-from ._invariants import instance_of, provider_of
+from ._invariants import provider_of
 from ._swagger import Swagger, VersionedPClasses
 
 spec = Swagger.from_path(FilePath(__file__).sibling(u"kubernetes-1.5.json"))

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -114,20 +114,11 @@ v1.Namespace = Namespace
 
 @provider(IObjectLoader)
 @implementer(IObject)
-class ConfigMap(PClass):
+class ConfigMap(v1.ConfigMap):
     """
     ``ConfigMap`` instances model `ConfigMap objects
     <https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_configmap>`_.
     """
-    kind = u"ConfigMap"
-
-    metadata = field(
-        mandatory=True,
-        invariant=instance_of(v1.ObjectMeta),
-    )
-
-    data = pmap_field(unicode, unicode, optional=True)
-
     @classmethod
     def from_raw(cls, raw):
         return cls(
@@ -166,6 +157,7 @@ class ConfigMap(PClass):
             result[u"data"] = thaw(self.data)
         return result
 
+v1.ConfigMap = ConfigMap
 
 
 def object_sort_key(obj):

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -21,6 +21,20 @@ from ._swagger import Swagger, VersionedPClasses
 spec = Swagger.from_path(FilePath(__file__).sibling(u"kubernetes-1.5.json"))
 v1 = VersionedPClasses(spec, u"v1", name_field=u"kind", version_field=u"apiVersion")
 
+
+def behavior(namespace):
+    """
+    Create a class decorator which adds the resulting class to the given
+    namespace-y thing.
+    """
+    def decorator(cls):
+        setattr(namespace, cls.__name__, cls)
+        return cls
+    return decorator
+
+
+
+@behavior(v1)
 class NamespaceStatus(v1.NamespaceStatus):
     """
     ``NamespaceStatus`` instances model `Kubernetes namespace status
@@ -44,10 +58,9 @@ class NamespaceStatus(v1.NamespaceStatus):
     def to_raw(self):
         return self.serialize()
 
-# Eeek?
-v1.NamespaceStatus = NamespaceStatus
 
 
+@behavior(v1)
 @provider(IObjectLoader)
 @implementer(IObject)
 class Namespace(v1.Namespace):
@@ -109,9 +122,9 @@ class Namespace(v1.Namespace):
             result[u"status"] = self.status.to_raw()
         return result
 
-v1.Namespace = Namespace
 
 
+@behavior(v1)
 @provider(IObjectLoader)
 @implementer(IObject)
 class ConfigMap(v1.ConfigMap):
@@ -157,7 +170,6 @@ class ConfigMap(v1.ConfigMap):
             result[u"data"] = thaw(self.data)
         return result
 
-v1.ConfigMap = ConfigMap
 
 
 def object_sort_key(obj):

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -44,6 +44,8 @@ class NamespaceStatus(v1.NamespaceStatus):
     def to_raw(self):
         return self.serialize()
 
+# Eeek?
+v1.NamespaceStatus = NamespaceStatus
 
 
 @provider(IObjectLoader)

--- a/src/txkube/_swagger.py
+++ b/src/txkube/_swagger.py
@@ -764,6 +764,10 @@ class VersionedPClasses(object):
             constant_fields[self.name_field] = name
         if self.version_field is not None:
             constant_fields[self.version_field] = self.version
-        return self.spec.pclass_for_definition(
-            self.version + u"." + name, constant_fields=constant_fields,
-        )
+        definition_name = self.version + u"." + name
+        try:
+            return self.spec.pclass_for_definition(
+                definition_name, constant_fields=constant_fields,
+            )
+        except KeyError:
+            raise AttributeError(name)

--- a/src/txkube/test/test_model.py
+++ b/src/txkube/test/test_model.py
@@ -20,7 +20,7 @@ from ..testing.strategies import (
 )
 
 from .. import (
-    v1, Namespace, ConfigMap, ObjectCollection,
+    v1, ConfigMap, ObjectCollection,
 )
 
 
@@ -46,14 +46,14 @@ def iobject_tests(loader, strategy):
 
 
 
-class RetrievableNamespaceTests(iobject_tests(Namespace, retrievable_namespaces)):
+class RetrievableNamespaceTests(iobject_tests(v1.Namespace, retrievable_namespaces)):
     """
     Tests for ``Namespace`` based on a strategy for fully-populated objects.
     """
 
 
 
-class CreatableNamespaceTests(iobject_tests(Namespace, creatable_namespaces)):
+class CreatableNamespaceTests(iobject_tests(v1.Namespace, creatable_namespaces)):
     """
     Tests for ``Namespace`` based on a strategy for objects just detailed
     enough to be created.
@@ -69,7 +69,7 @@ class NamespaceTests(TestCase):
         ``Namespace.default`` returns the *default* namespace.
         """
         self.assertThat(
-            Namespace.default(),
+            v1.Namespace.default(),
             MatchesStructure(
                 metadata=MatchesStructure(
                     name=Equals(u"default"),
@@ -85,7 +85,7 @@ class NamespaceTests(TestCase):
         name.
         """
         self.assertThat(
-            Namespace.named(name),
+            v1.Namespace.named(name),
             MatchesStructure(
                 metadata=MatchesStructure(
                     name=Equals(name),
@@ -100,7 +100,7 @@ class NamespaceTests(TestCase):
         """
         # If they are not set already, a uid is generated and put into the
         # metadata and the status is set to active.
-        sparse = Namespace.named(u"foo")
+        sparse = v1.Namespace.named(u"foo")
         filled = sparse.fill_defaults()
         self.expectThat(
             filled,

--- a/src/txkube/test/test_model.py
+++ b/src/txkube/test/test_model.py
@@ -20,7 +20,7 @@ from ..testing.strategies import (
 )
 
 from .. import (
-    Namespace, NamespaceStatus, ConfigMap, ObjectCollection,
+    v1, Namespace, ConfigMap, ObjectCollection,
 )
 
 
@@ -108,7 +108,7 @@ class NamespaceTests(TestCase):
                 metadata=MatchesStructure(
                     uid=Not(Is(None)),
                 ),
-                status=Equals(NamespaceStatus.active()),
+                status=Equals(v1.NamespaceStatus.active()),
             ),
         )
 

--- a/src/txkube/test/test_model.py
+++ b/src/txkube/test/test_model.py
@@ -19,10 +19,7 @@ from ..testing.strategies import (
     objectcollections,
 )
 
-from .. import (
-    v1, ConfigMap, ObjectCollection,
-)
-
+from .. import v1, ObjectCollection
 
 
 def iobject_tests(loader, strategy):
@@ -114,7 +111,7 @@ class NamespaceTests(TestCase):
 
 
 
-class ConfigMapTests(iobject_tests(ConfigMap, configmaps)):
+class ConfigMapTests(iobject_tests(v1.ConfigMap, configmaps)):
     """
     Tests for ``ConfigMap``.
     """
@@ -125,7 +122,7 @@ class ConfigMapTests(iobject_tests(ConfigMap, configmaps)):
         namespace and name.
         """
         self.assertThat(
-            ConfigMap.named(namespace, name),
+            v1.ConfigMap.named(namespace, name),
             MatchesStructure(
                 metadata=MatchesStructure(
                     namespace=Equals(namespace),

--- a/src/txkube/test/test_swagger.py
+++ b/src/txkube/test/test_swagger.py
@@ -646,3 +646,13 @@ class VersionedPClassesTests(TestCase):
         """
         a = VersionedPClasses(self.spec, u"a", version_field=u"version")
         self.assertThat(a.foo().version, Equals(u"a"))
+
+
+    def test_missing(self):
+        """
+        An attribute access on ``VersionedPClasses`` for which there is no
+        corresponding Swagger definition results in ``AttributeError`` being
+        raised.
+        """
+        a = VersionedPClasses(self.spec, u"a", version_field=u"version")
+        self.assertThat(lambda: a.bar, raises(AttributeError("bar")))

--- a/src/txkube/testing/integration.py
+++ b/src/txkube/testing/integration.py
@@ -28,7 +28,7 @@ from ..testing import TestCase
 # TODO #18 this moved to txkube/__init__.py
 from .._network import KubernetesError
 from .. import (
-    IKubernetesClient, ConfigMap, ObjectCollection,
+    IKubernetesClient, ObjectCollection,
     v1,
 )
 from .strategies import creatable_namespaces, configmaps
@@ -205,7 +205,7 @@ def kubernetes_client_tests(get_kubernetes):
             d.addCallback(created_namespace)
             def created_configmap(created):
                 self.assertThat(created, matches_configmap(obj))
-                return self.client.list(ConfigMap)
+                return self.client.list(v1.ConfigMap)
             d.addCallback(created_configmap)
             def check_configmaps(collection):
                 self.assertThat(collection, IsInstance(ObjectCollection))
@@ -261,7 +261,7 @@ def kubernetes_client_tests(get_kubernetes):
             """
             return self._namespaced_object_retrieval_by_name_test(
                 configmaps(),
-                ConfigMap,
+                v1.ConfigMap,
                 matches_configmap,
             )
 
@@ -284,7 +284,7 @@ def kubernetes_client_tests(get_kubernetes):
             )
             d = gatherResults(list(self.client.create(obj) for obj in ns + objs))
             def created_configmaps(ignored):
-                return self.client.list(ConfigMap)
+                return self.client.list(v1.ConfigMap)
             d.addCallback(created_configmaps)
             def check_configmaps(collection):
                 self.expectThat(collection, items_are_sorted())

--- a/src/txkube/testing/integration.py
+++ b/src/txkube/testing/integration.py
@@ -28,7 +28,7 @@ from ..testing import TestCase
 # TODO #18 this moved to txkube/__init__.py
 from .._network import KubernetesError
 from .. import (
-    IKubernetesClient, NamespaceStatus, Namespace, ConfigMap, ObjectCollection,
+    IKubernetesClient, Namespace, ConfigMap, ObjectCollection,
     v1,
 )
 from .strategies import creatable_namespaces, configmaps
@@ -70,7 +70,7 @@ def has_uid():
 
 def is_active():
     return MatchesStructure(
-        status=Equals(NamespaceStatus.active()),
+        status=Equals(v1.NamespaceStatus.active()),
     )
 
 

--- a/src/txkube/testing/integration.py
+++ b/src/txkube/testing/integration.py
@@ -28,7 +28,7 @@ from ..testing import TestCase
 # TODO #18 this moved to txkube/__init__.py
 from .._network import KubernetesError
 from .. import (
-    IKubernetesClient, Namespace, ConfigMap, ObjectCollection,
+    IKubernetesClient, ConfigMap, ObjectCollection,
     v1,
 )
 from .strategies import creatable_namespaces, configmaps
@@ -112,7 +112,7 @@ def kubernetes_client_tests(get_kubernetes):
             d = self.client.create(obj)
             def created_namespace(created):
                 self.assertThat(created, matches_namespace(obj))
-                return self.client.list(Namespace)
+                return self.client.list(v1.Namespace)
             d.addCallback(created_namespace)
             def check_namespaces(namespaces):
                 self.assertThat(namespaces, IsInstance(ObjectCollection))
@@ -153,7 +153,7 @@ def kubernetes_client_tests(get_kubernetes):
             """
             return self._global_object_retrieval_by_name_test(
                 creatable_namespaces(),
-                Namespace,
+                v1.Namespace,
                 matches_namespace,
             )
 
@@ -170,7 +170,7 @@ def kubernetes_client_tests(get_kubernetes):
                 return self.client.delete(created)
             d.addCallback(created_namespace)
             def deleted_namespace(ignored):
-                return self.client.list(Namespace)
+                return self.client.list(v1.Namespace)
             d.addCallback(deleted_namespace)
             def check_namespaces(collection):
                 active = list(
@@ -275,7 +275,7 @@ def kubernetes_client_tests(get_kubernetes):
             strategy = configmaps()
             objs = [strategy.example(), strategy.example()]
             ns = list(
-                Namespace(
+                v1.Namespace(
                     metadata=v1.ObjectMeta(name=obj.metadata.namespace),
                     status=None,
                 )

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -13,7 +13,6 @@ from hypothesis.strategies import (
 )
 
 from .. import (
-    NamespaceStatus,
     v1, Namespace, ConfigMap,
     ObjectCollection,
 )
@@ -71,7 +70,7 @@ def namespace_statuses():
     Strategy to build ``Namespace.status``.
     """
     return builds(
-        NamespaceStatus,
+        v1.NamespaceStatus,
         phase=sampled_from({u"Active", u"Terminating"}),
     )
 

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -13,7 +13,7 @@ from hypothesis.strategies import (
 )
 
 from .. import (
-    v1, Namespace, ConfigMap,
+    v1, ConfigMap,
     ObjectCollection,
 )
 
@@ -81,7 +81,7 @@ def creatable_namespaces():
     cluster.
     """
     return builds(
-        Namespace,
+        v1.Namespace,
         metadata=object_metadatas(),
         status=none(),
     )

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -12,10 +12,7 @@ from hypothesis.strategies import (
     dictionaries,
 )
 
-from .. import (
-    v1, ConfigMap,
-    ObjectCollection,
-)
+from .. import v1, ObjectCollection
 
 # Without some attempt to cap the size of collection strategies (lists,
 # dictionaries), the slowness health check fails intermittently.  Here are
@@ -142,7 +139,7 @@ def configmaps():
     Strategy to build ``ConfigMap``.
     """
     return builds(
-        ConfigMap,
+        v1.ConfigMap,
         metadata=namespaced_object_metadatas(),
         data=configmap_datas(),
     )


### PR DESCRIPTION
Fixes #50 

Note I ended up leaving ObjectCollection alone because it's a little more complicated and I have some related changes outstanding in another branch that I don't want to conflict too badly with.  It seems like that ObjectCollection will go away and be replaced by a number of type-specific `...List` classes (eg `NamespaceList`) since that's what's actually in the spec.  But - later.