### PR TITLE
Generalized serialization functions

### DIFF
--- a/src/txkube/__init__.py
+++ b/src/txkube/__init__.py
@@ -7,11 +7,13 @@ A Kubernetes client.
 
 __all__ = [
     "version",
-    "IObject", "IObjectLoader", "IKubernetes", "IKubernetesClient",
-    "network_client", "memory_client",
+    "IObject", "IKubernetes", "IKubernetesClient",
 
     "v1",
     "object_from_raw",
+    "iobject_from_raw",
+    "iobject_to_raw",
+
     "ObjectCollection",
 
     "memory_kubernetes",
@@ -25,11 +27,13 @@ from incremental import Version
 from ._metadata import version_tuple as _version_tuple
 version = Version("txkube", *_version_tuple)
 
-from ._interface import IObject, IObjectLoader, IKubernetes, IKubernetesClient
+from ._interface import IObject, IKubernetes, IKubernetesClient
 
 from ._model import (
     v1,
     object_from_raw,
+    iobject_from_raw,
+    iobject_to_raw,
     ObjectCollection,
 )
 

--- a/src/txkube/__init__.py
+++ b/src/txkube/__init__.py
@@ -9,12 +9,7 @@ __all__ = [
     "version",
     "IObject", "IKubernetes", "IKubernetesClient",
 
-    "v1",
-    "object_from_raw",
-    "iobject_from_raw",
-    "iobject_to_raw",
-
-    "ObjectCollection",
+    "v1", "iobject_from_raw", "iobject_to_raw",
 
     "memory_kubernetes",
     "network_kubernetes",  "network_kubernetes_from_context",
@@ -31,10 +26,8 @@ from ._interface import IObject, IKubernetes, IKubernetesClient
 
 from ._model import (
     v1,
-    object_from_raw,
     iobject_from_raw,
     iobject_to_raw,
-    ObjectCollection,
 )
 
 from ._authentication import (

--- a/src/txkube/_interface.py
+++ b/src/txkube/_interface.py
@@ -17,6 +17,10 @@ class IObject(Interface):
         """The Kubernetes *kind* of this object.  For example, ``u"Namespace"``."""
     )
 
+    apiVersion = Attribute(
+        """The Kubernetes *apiVersion* of this object.  For example, ``u"v1"``."""
+    )
+
     metadata = Attribute(
         """
         The metadata for this object.  As either ``ObjectMetadata`` or
@@ -24,29 +28,14 @@ class IObject(Interface):
         """
     )
 
-    def to_raw():
+    def serialize():
         """
         Marshal this object to a JSON- and YAML-compatible object graph.
 
-        This is the inverse of ``IObjectLoader.from_raw``.
-
         :return dict: A JSON-compatible representation of this object.
+            ``kind`` and ``apiVersion`` may be omitted.
         """
 
-
-class IObjectLoader(Interface):
-    """
-    ``IObjectLoader`` providers can take a marshalled dump of a Kubernetes
-    object (ie, the JSON- or YAML-compatible object graph) and create a
-    corresponding ``IObject`` provider with a more convenient Python
-    interface.
-    """
-    def from_raw(raw):
-        """
-        Load the ``IObject``.
-
-        This is the inverse of ``IObject.to_raw``.
-        """
 
 
 class IKubernetes(Interface):

--- a/src/txkube/_memory.py
+++ b/src/txkube/_memory.py
@@ -25,7 +25,7 @@ from treq.testing import RequestTraversalAgent
 
 from . import (
     IKubernetes, network_kubernetes,
-    v1, ObjectCollection,
+    v1,
     iobject_from_raw, iobject_to_raw,
 )
 
@@ -74,8 +74,8 @@ def _kubernetes_resource(state):
 
 @attr.s
 class _KubernetesState(object):
-    namespaces = attr.ib(default=ObjectCollection())
-    configmaps = attr.ib(default=ObjectCollection())
+    namespaces = attr.ib(default=v1.NamespaceList())
+    configmaps = attr.ib(default=v1.ConfigMapList())
 
 
 def terminate(obj):
@@ -107,7 +107,7 @@ class _Kubernetes(object):
         if namespace is not None:
             collection = self._reduce_to_namespace(collection, namespace)
         request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])
-        return dumps(collection.to_raw())
+        return dumps(iobject_to_raw(collection))
 
     def _get(self, request, collection, namespace, name):
         request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])

--- a/src/txkube/_memory.py
+++ b/src/txkube/_memory.py
@@ -26,6 +26,7 @@ from treq.testing import RequestTraversalAgent
 from . import (
     IKubernetes, network_kubernetes,
     v1, ObjectCollection,
+    iobject_from_raw, iobject_to_raw,
 )
 
 
@@ -120,20 +121,20 @@ class _Kubernetes(object):
             # This is definitely not the right result.
             return dumps({})
         else:
-            return dumps(obj.to_raw())
+            return dumps(iobject_to_raw(obj))
 
     def _create(self, request, type, collection, collection_name):
-        obj = type.from_raw(loads(request.content.read())).fill_defaults()
+        obj = iobject_from_raw(loads(request.content.read())).fill_defaults()
         setattr(self.state, collection_name, collection.add(obj))
         request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])
         request.setResponseCode(CREATED)
-        return dumps(obj.to_raw())
+        return dumps(iobject_to_raw(obj))
 
     def _delete(self, request, collection, collection_name, name):
         obj = collection.item_by_name(name)
         setattr(self.state, collection_name, collection.replace(obj, terminate(obj)))
         request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])
-        return dumps(obj.to_raw())
+        return dumps(iobject_to_raw(obj))
 
     app = Klein()
     @app.handle_errors(NotFound)

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -194,7 +194,7 @@ class ObjectCollection(PClass):
     @classmethod
     def from_raw(cls, raw):
         element_kind = raw[u"kind"][:-len(u"List")]
-        element_version = self.apiVersion
+        element_version = cls.apiVersion
 
         items = (
             # Unfortunately `kind` is an optional field.  Fortunately, the

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -158,6 +158,10 @@ class _List(object):
         return self.transform([u"items"], add(obj))
 
 
+    def remove(self, obj):
+        return self.transform([u"items"], remove(obj))
+
+
     def replace(self, old, new):
         return self.transform(
             [u"items"], remove(old),

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -10,12 +10,11 @@ from uuid import uuid4
 
 from zope.interface import implementer
 
-from pyrsistent import CheckedPVector, PClass, field, thaw, mutant
+from pyrsistent import thaw, mutant
 
 from twisted.python.filepath import FilePath
 
 from . import IObject
-from ._invariants import provider_of
 from ._swagger import Swagger, VersionedPClasses
 
 spec = Swagger.from_path(FilePath(__file__).sibling(u"kubernetes-1.5.json"))

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -49,10 +49,6 @@ class NamespaceStatus(v1.NamespaceStatus):
         return cls(phase=u"Terminating")
 
 
-    def to_raw(self):
-        return self.serialize()
-
-
 
 @behavior(v1)
 @implementer(IObject)
@@ -90,18 +86,6 @@ class Namespace(v1.Namespace):
         )
 
 
-    def to_raw(self):
-        result = {
-            u"kind": self.kind,
-            u"apiVersion": u"v1",
-            u"metadata": self.metadata.serialize(),
-            u"spec": {},
-        }
-        if self.status is not None:
-            result[u"status"] = self.status.to_raw()
-        return result
-
-
 
 @behavior(v1)
 @implementer(IObject)
@@ -124,21 +108,6 @@ class ConfigMap(v1.ConfigMap):
         # TODO Surely some stuff to fill.
         # See https://github.com/LeastAuthority/txkube/issues/36
         return self
-
-
-    def to_raw(self):
-        result = {
-            u"kind": self.kind,
-            u"apiVersion": u"v1",
-            u"metadata": self.metadata.serialize(),
-        }
-        if self.data is not None:
-            # Kubernetes only includes the item if there is some data.
-            #
-            # XXX I'm not sure if there's a difference between no data and
-            # data with no items.
-            result[u"data"] = thaw(self.data)
-        return result
 
 
 

--- a/src/txkube/_model.py
+++ b/src/txkube/_model.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from zope.interface import implementer
 
-from pyrsistent import thaw, mutant
+from pyrsistent import mutant
 
 from twisted.python.filepath import FilePath
 

--- a/src/txkube/_network.py
+++ b/src/txkube/_network.py
@@ -34,7 +34,6 @@ from pykube import KubeConfig
 
 from . import (
     IObject, IKubernetes, IKubernetesClient,
-    ObjectCollection,
     iobject_from_raw, iobject_to_raw,
     authenticate_with_certificate,
 )
@@ -237,7 +236,7 @@ class _NetworkClient(object):
             d.addCallback(check_status, (OK,))
             d.addCallback(readBody)
             d.addCallback(loads)
-            d.addCallback(ObjectCollection.from_raw)
+            d.addCallback(iobject_from_raw)
             return d.addActionFinish()
 
 

--- a/src/txkube/_network.py
+++ b/src/txkube/_network.py
@@ -34,7 +34,9 @@ from pykube import KubeConfig
 
 from . import (
     IObject, IKubernetes, IKubernetesClient,
-    object_from_raw, authenticate_with_certificate,
+    ObjectCollection,
+    iobject_from_raw, iobject_to_raw,
+    authenticate_with_certificate,
 )
 
 def network_kubernetes(**kw):
@@ -167,14 +169,14 @@ class _NetworkClient(object):
         )
         with action.context():
             url = self.kubernetes.base_url.child(*collection_location(obj))
-            document = obj.to_raw()
+            document = iobject_to_raw(obj)
             action.add_success_fields(submitted_object=document)
             d = DeferredContext(self._post(url, document))
             d.addCallback(check_status, (CREATED,))
             d.addCallback(readBody)
             d.addCallback(loads)
             d.addCallback(log_response_object, action)
-            d.addCallback(object_from_raw)
+            d.addCallback(iobject_from_raw)
             return d.addActionFinish()
 
 
@@ -198,7 +200,7 @@ class _NetworkClient(object):
             d.addCallback(readBody)
             d.addCallback(loads)
             d.addCallback(log_response_object, action)
-            d.addCallback(object_from_raw)
+            d.addCallback(iobject_from_raw)
             return d.addActionFinish()
 
 
@@ -235,7 +237,7 @@ class _NetworkClient(object):
             d.addCallback(check_status, (OK,))
             d.addCallback(readBody)
             d.addCallback(loads)
-            d.addCallback(object_from_raw)
+            d.addCallback(ObjectCollection.from_raw)
             return d.addActionFinish()
 
 

--- a/src/txkube/test/test_model.py
+++ b/src/txkube/test/test_model.py
@@ -8,7 +8,7 @@ Tests for ``txkube._model``.
 from json import loads, dumps
 
 from testtools.matchers import (
-    Equals, LessThan, MatchesStructure, Not, Is,
+    Equals, MatchesStructure, Not, Is,
 )
 
 from hypothesis import given, assume
@@ -18,7 +18,6 @@ from ..testing.matchers import PClassEquals, MappingEquals
 from ..testing.strategies import (
     object_name,
     iobjects,
-    creatable_namespaces,
 )
 
 from .. import v1, iobject_to_raw, iobject_from_raw

--- a/src/txkube/test/test_model.py
+++ b/src/txkube/test/test_model.py
@@ -17,11 +17,11 @@ from ..testing import TestCase
 from ..testing.matchers import PClassEquals, MappingEquals
 from ..testing.strategies import (
     object_name,
-    configmaps,
     iobjects,
+    creatable_namespaces,
 )
 
-from .. import v1, ObjectCollection, iobject_to_raw, iobject_from_raw
+from .. import v1, iobject_to_raw, iobject_from_raw
 
 
 class IObjectTests(TestCase):
@@ -136,30 +136,4 @@ class ConfigMapTests(TestCase):
                     name=Equals(name),
                 ),
             ),
-        )
-
-
-
-class ObjectCollectionTests(TestCase):
-    """
-    Tests for ``ObjectCollection``.
-    """
-    @given(a=configmaps(), b=configmaps())
-    def test_items_sorted(self, a, b):
-        """
-        ``ObjectCollection.items`` is sorted by (namespace, name) regardless of
-        the order given to the initializer.
-        """
-        assume(
-            (a.metadata.namespace, a.metadata.name)
-            != (b.metadata.namespace, b.metadata.name)
-        )
-
-        collection = ObjectCollection(items=[a, b])
-        first = collection.items[0].metadata
-        second = collection.items[1].metadata
-
-        self.assertThat(
-            (first.namespace, first.name),
-            LessThan((second.namespace, second.name)),
         )

--- a/src/txkube/testing/integration.py
+++ b/src/txkube/testing/integration.py
@@ -28,7 +28,7 @@ from ..testing import TestCase
 # TODO #18 this moved to txkube/__init__.py
 from .._network import KubernetesError
 from .. import (
-    IKubernetesClient, ObjectCollection,
+    IKubernetesClient,
     v1,
 )
 from .strategies import creatable_namespaces, configmaps
@@ -115,7 +115,7 @@ def kubernetes_client_tests(get_kubernetes):
                 return self.client.list(v1.Namespace)
             d.addCallback(created_namespace)
             def check_namespaces(namespaces):
-                self.assertThat(namespaces, IsInstance(ObjectCollection))
+                self.assertThat(namespaces, IsInstance(v1.NamespaceList))
                 # There are some built-in namespaces that we'll ignore.  If we
                 # find the one we created, that's sufficient.
                 self.assertThat(
@@ -208,7 +208,7 @@ def kubernetes_client_tests(get_kubernetes):
                 return self.client.list(v1.ConfigMap)
             d.addCallback(created_configmap)
             def check_configmaps(collection):
-                self.assertThat(collection, IsInstance(ObjectCollection))
+                self.assertThat(collection, IsInstance(v1.ConfigMapList))
                 self.assertThat(collection.items, AnyMatch(matches_configmap(obj)))
             d.addCallback(check_configmaps)
             return d

--- a/src/txkube/testing/matchers.py
+++ b/src/txkube/testing/matchers.py
@@ -1,0 +1,126 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+testtools matchers for txkube.
+"""
+
+import operator
+
+import attr
+
+from pyrsistent import PClass, field
+
+from testtools.matchers import Mismatch
+
+
+class MappingLikeEquals(PClass):
+    expected = field()
+
+    comparator = operator.eq
+    mismatch_string = "!="
+
+    def __new__(cls, expected):
+        # Provide positional argument support.
+        # https://github.com/tobgu/pyrsistent/issues/94
+        return super(MappingLikeEquals, cls).__new__(cls, expected=expected)
+
+
+    def fields(self, obj):
+        raise NotImplementedError()
+
+
+    def get_field(self, obj, field):
+        raise NotImplementedError()
+
+
+    def __str__(self):
+        return "%s(%r)" % (self.__class__.__name__, self.expected)
+
+
+    def match(self, other):
+        if self.comparator(other, self.expected):
+            return None
+        return _MappingLikeMismatch(
+            self.fields, self.get_field, other, self.mismatch_string,
+            self.expected,
+        )
+
+
+
+class MappingEquals(MappingLikeEquals):
+    def fields(self, obj):
+        return obj.keys()
+
+
+    def get_field(self, obj, key):
+        return obj[key]
+
+
+
+class AttrsEquals(MappingLikeEquals):
+    def fields(self, obj):
+        return list(field.name for field in attr.fields(type(obj)))
+
+
+    def get_field(self, obj, key):
+        return getattr(obj, key)
+
+
+
+class PClassEquals(MappingLikeEquals):
+    def fields(self, obj):
+        return obj._pclass_fields.keys()
+
+
+    def get_field(self, obj, key):
+        return getattr(obj, key)
+
+
+
+class _MappingLikeMismatch(Mismatch):
+    def __init__(self, get_fields, get_field, actual, mismatch_string, reference,
+                 reference_on_right=True):
+        self._get_fields = get_fields
+        self._get_field = get_field
+        self._actual = actual
+        self._mismatch_string = mismatch_string
+        self._reference = reference
+        self._reference_on_right = reference_on_right
+
+
+    def describe(self):
+        if type(self._actual) != type(self._reference):
+            return (
+                "type mismatch:\n"
+                "reference = %s\n"
+                "actual    = %s\n"
+            ) % (
+                type(self._reference),
+                type(self._actual),
+            )
+
+        mismatched = []
+        fields = self._get_fields(self._actual)
+        for a_field in sorted(fields):
+            actual = self._get_field(self._actual, a_field)
+            try:
+                reference = self._get_field(self._reference, a_field)
+            except KeyError:
+                mismatched.append((a_field, actual, "<<missing>>"))
+            else:
+                if actual != reference:
+                    mismatched.append((a_field, actual, reference))
+
+        extra = set(self._get_fields(self._reference)) - set(fields)
+        for a_field in sorted(extra):
+            reference = self._get_field(self._reference, a_field)
+            mismatched.append((a_field, "<<missing>>", reference))
+
+        return "field mismatch:\n" + "".join(
+            "field: %s\n"
+            "reference = %s\n"
+            "actual    = %s\n" % mismatch
+            for mismatch
+            in mismatched
+        )

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -12,7 +12,7 @@ from hypothesis.strategies import (
     dictionaries,
 )
 
-from .. import v1, ObjectCollection
+from .. import v1
 
 # Without some attempt to cap the size of collection strategies (lists,
 # dictionaries), the slowness health check fails intermittently.  Here are
@@ -145,26 +145,43 @@ def configmaps():
     )
 
 
+def configmaplists():
+    """
+    Strategy to build ``ConfigMapList``.
+    """
+    return builds(
+        v1.ConfigMapList,
+        items=lists(
+            configmaps(),
+            average_size=_QUICK_AVERAGE_SIZE,
+            max_size=_QUICK_MAX_SIZE,
+            unique_by=_unique_names_with_namespaces,
+        ),
+    )
+
+
+def namespacelists(namespaces=creatable_namespaces()):
+    """
+    Strategy to build ``NamespaceList``.
+    """
+    return builds(
+        v1.NamespaceList,
+        items=lists(
+            namespaces,
+            average_size=_QUICK_AVERAGE_SIZE,
+            max_size=_QUICK_MAX_SIZE,
+            unique_by=_unique_names_with_namespaces,
+        ),
+    )
+
+
 def objectcollections(namespaces=creatable_namespaces()):
     """
     Strategy to build ``ObjectCollection``.
     """
-    return builds(
-        ObjectCollection,
-        items=one_of(
-            lists(
-                namespaces,
-                average_size=_QUICK_AVERAGE_SIZE,
-                max_size=_QUICK_MAX_SIZE,
-                unique_by=_unique_names,
-            ),
-            lists(
-                configmaps(),
-                average_size=_QUICK_AVERAGE_SIZE,
-                max_size=_QUICK_MAX_SIZE,
-                unique_by=_unique_names_with_namespaces,
-            ),
-        ),
+    return one_of(
+        configmaplists(),
+        namespacelists(namespaces),
     )
 
 

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -170,7 +170,7 @@ def namespacelists(namespaces=creatable_namespaces()):
             namespaces,
             average_size=_QUICK_AVERAGE_SIZE,
             max_size=_QUICK_MAX_SIZE,
-            unique_by=_unique_names_with_namespaces,
+            unique_by=_unique_names,
         ),
     )
 

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -182,3 +182,15 @@ def _unique_names_with_namespaces(item):
     collection.
     """
     return (item.metadata.name, item.metadata.namespace)
+
+
+def iobjects():
+    """
+    Strategy to build any one of the ``IObject`` implementations.
+    """
+    return one_of(
+        creatable_namespaces(),
+        retrievable_namespaces(),
+        configmaps(),
+        objectcollections(),
+    )

--- a/src/txkube/testing/test/__init__.py
+++ b/src/txkube/testing/test/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Tests for ``txkube.testing``.
+"""

--- a/src/txkube/testing/test/test_matchers.py
+++ b/src/txkube/testing/test/test_matchers.py
@@ -1,0 +1,206 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Tests for ``txkube.testing.matchers``.
+"""
+
+import attr
+
+from pyrsistent import PClass, field
+
+from testtools.matchers import Is, Equals
+
+from .. import TestCase
+from ..matchers import MappingEquals, AttrsEquals, PClassEquals
+
+
+class MappingEqualsTests(TestCase):
+    """
+    Tests for ``MappingEquals``.
+    """
+    def test_equals(self):
+        """
+        ``MappingEquals.match`` returns ``None`` when comparing two ``dict`` which
+        compare equal with ``==``.
+        """
+        self.assertThat(
+            MappingEquals({u"foo": u"bar"}).match({u"foo": u"bar"}),
+            Is(None),
+        )
+
+
+    def test_mismatch(self):
+        """
+        ``MappingEquals.match`` returns a mismatch when comparing two ``dict``
+        which do not compare equal with ``==``.
+        """
+        # Same keys, different value.
+        mismatch = MappingEquals({u"foo": u"bar"}).match({u"foo": u"baz"})
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = bar\n"
+                u"actual    = baz\n"
+            ),
+        )
+
+        # Different types altogether.
+        mismatch = MappingEquals(object()).match({u"foo": u"baz"})
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"type mismatch:\n"
+                u"reference = <type 'object'>\n"
+                u"actual    = <type 'dict'>\n"
+            ),
+        )
+
+        # Actual value missing a key.
+        mismatch = MappingEquals({u"foo": u"bar"}).match({})
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = bar\n"
+                u"actual    = <<missing>>\n"
+            ),
+        )
+
+        # Expected value missing a key.
+        mismatch = MappingEquals({}).match({u"foo": u"baz"})
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = <<missing>>\n"
+                u"actual    = baz\n"
+            ),
+        )
+
+
+
+class AttrsEqualsTests(TestCase):
+    """
+    Tests for ``AttrsEquals``.
+    """
+    @attr.s
+    class attrs(object):
+        foo = attr.ib()
+
+
+    def test_equals(self):
+        """
+        ``AttrsEquals.match`` returns ``None`` when comparing two attrs-based
+        instances which compare equal with ``==``.
+        """
+        self.assertThat(
+            AttrsEquals(self.attrs(u"bar")).match(self.attrs(u"bar")),
+            Is(None),
+        )
+
+
+    def test_mismatch(self):
+        """
+        ``AttrsEquals.match`` returns a mismatch when comparing two attrs-based
+        instances which do not compare equal with ``==``.
+        """
+        # Different value for the single attribute.
+        mismatch = AttrsEquals(self.attrs(u"bar")).match(self.attrs(u"baz"))
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = bar\n"
+                u"actual    = baz\n"
+            ),
+        )
+
+        # Different types altogether.
+        mismatch = AttrsEquals(self.attrs(u"bar")).match(object())
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"type mismatch:\n"
+                u"reference = <class 'txkube.testing.test.test_matchers.attrs'>\n"
+                u"actual    = <type 'object'>\n"
+            ),
+        )
+
+
+
+class PClassEqualsTests(TestCase):
+    """
+    Tests for ``PClassEquals``.
+    """
+    class pclass(PClass):
+        foo = field()
+
+
+    def test_equals(self):
+        """
+        ``PClassEquals.match`` returns ``None`` when comparing two PClass-based
+        instances which compare equal with ``==``.
+        """
+        self.assertThat(
+            PClassEquals(self.pclass(foo=u"bar")).match(self.pclass(foo=u"bar")),
+            Is(None),
+        )
+
+
+    def test_mismatch(self):
+        """
+        ``PClassEquals.match`` returns a mismatch when comparing two ``dict``
+        which do not compare equal with ``==``.
+        """
+        # Same attributes, different value.
+        mismatch = PClassEquals(self.pclass(foo=u"bar")).match(self.pclass(foo=u"baz"))
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = bar\n"
+                u"actual    = baz\n"
+            ),
+        )
+
+        # Different types altogether.
+        mismatch = PClassEquals(object()).match(self.pclass(foo=u"baz"))
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"type mismatch:\n"
+                u"reference = <type 'object'>\n"
+                u"actual    = <class 'txkube.testing.test.test_matchers.pclass'>\n"
+            ),
+        )
+
+        # Actual value missing an attribute.
+        mismatch = PClassEquals(self.pclass(foo=u"bar")).match(self.pclass())
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = bar\n"
+                u"actual    = <<missing>>\n"
+            ),
+        )
+
+        # Expected value missing an attribute.
+        mismatch = PClassEquals(self.pclass()).match(self.pclass(foo=u"baz"))
+        self.expectThat(
+            mismatch.describe(),
+            Equals(
+                u"field mismatch:\n"
+                u"field: foo\n"
+                u"reference = <<missing>>\n"
+                u"actual    = baz\n"
+            ),
+        )

--- a/src/txkube/testing/test/test_matchers.py
+++ b/src/txkube/testing/test/test_matchers.py
@@ -82,6 +82,12 @@ class MappingEqualsTests(TestCase):
             ),
         )
 
+        # The matcher has a nice string representation.
+        self.expectThat(
+            str(MappingEquals({})),
+            Equals("MappingEquals({})"),
+        )
+
 
 
 class AttrsEqualsTests(TestCase):
@@ -132,6 +138,12 @@ class AttrsEqualsTests(TestCase):
             ),
         )
 
+        # The matcher has a nice string representation.
+        self.expectThat(
+            str(AttrsEquals(self.attrs(u"bar"))),
+            Equals("AttrsEquals(attrs(foo=u'bar'))"),
+        )
+
 
 
 class PClassEqualsTests(TestCase):
@@ -140,6 +152,7 @@ class PClassEqualsTests(TestCase):
     """
     class pclass(PClass):
         foo = field()
+        bar = field()
 
 
     def test_equals(self):
@@ -203,4 +216,10 @@ class PClassEqualsTests(TestCase):
                 u"reference = <<missing>>\n"
                 u"actual    = baz\n"
             ),
+        )
+
+        # The matcher has a nice string representation.
+        self.expectThat(
+            str(PClassEquals(self.pclass(foo=u"bar"))),
+            Equals("PClassEquals(pclass(foo=u'bar'))"),
         )


### PR DESCRIPTION
Fixes #55 
Fixes #54 

`ObjectCollection` serialization was tied up in the existing deserialization logic so it was easiest to do away with `ObjectCollection` at the same time. 