### PR TITLE
Fix diverging string/date-time attribute behavior

### DIFF
--- a/src/txkube/_swagger.py
+++ b/src/txkube/_swagger.py
@@ -53,7 +53,7 @@ class Swagger(PClass):
     """
     info = field()
     paths = field()
-    definitions = field(factory=pmap)
+    definitions = field(factory=freeze)
     securityDefinitions = field()
     security = field()
     swagger = field()

--- a/src/txkube/test/test_swagger.py
+++ b/src/txkube/test/test_swagger.py
@@ -322,6 +322,15 @@ class SwaggerTests(TestCase):
             Type(s=now).serialize(),
             Equals({u"s": now.isoformat().decode("ascii")}),
         )
+        # Missing values don't appear in the output.
+        self.expectThat(
+            Type(s=None).serialize(),
+            Equals({}),
+        )
+        self.expectThat(
+            Type().serialize(),
+            Equals({}),
+        )
 
 
     def test_string_int_or_string(self):


### PR DESCRIPTION
Merges _DatetimeTypeModel into _BasicTypeModel to remove the possibility and temptation to make datetime's special.

Fixes #59 