### PR TITLE
[DO NOT MERGE] Some attempts at 17.5 fixes.

### DIFF
--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -23,7 +23,7 @@ from eliot.testing import capture_logging
 
 from OpenSSL.crypto import FILETYPE_PEM
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.test.proto_helpers import MemoryReactorClock as MemoryReactor
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
 from twisted.python.filepath import FilePath
@@ -371,12 +371,17 @@ class Redirectable(proxyForInterface(IReactorSSL)):
     """
     original = attr.ib()
 
+    def seconds(self):
+        return self.original.seconds()
+
+    def callLater(self, *args, **kwargs):
+        return self.original.callLater(*args, **kwargs)
+
     def set_redirect(self, host, port):
         """
         Specify the alternate address to which connections will be directed.
         """
         self.host, self.port = host, port
-
 
     def connectSSL(self, host, port, *a, **kw):
         """
@@ -384,3 +389,10 @@ class Redirectable(proxyForInterface(IReactorSSL)):
         address.
         """
         return self.original.connectSSL(self.host, self.port, *a, **kw)
+
+    def connectTCP(self, host, port, *a, **kw):
+        """
+        Establish a TLS connection to the alternate address instead of the given
+        address.
+        """
+        return self.original.connectTCP(self.host, self.port, *a, **kw)


### PR DESCRIPTION
@exarkun 

This contains fixes for most of the issues present in 17.1 and 17.5, although I've only tested on 17.5. This code is in no way ready for landing, but it does identify the issues so that you may tackle them in a cleaner way :)

The largest change is that connectSSL isn't used by Agent anymore, it's a regular TCP connection with a wrapped protocol. This causes the failure I haven't fixed in `test_https_bearer_token_authorization`, and would need a special 17.1+ codepath to verify that it's doing the right thing.

Feel free to use the code, even though it's not up to spec :)