### PR TITLE
Fix Redirectable to work with Twisted 17.5.0

### DIFF
--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -32,7 +32,7 @@ from twisted.python.filepath import FilePath
 from twisted.internet.protocol import Factory
 from twisted.web.http_headers import Headers
 from twisted.test.iosim import ConnectionCompleter
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactor
+from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactorClock
 
 from ..testing import TestCase
 
@@ -83,7 +83,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactor()
+        reactor = MemoryReactorClock()
         reactor.listenTCP(80, factory)
 
         t = FilePath(self.useFixture(TempDir()).join(b""))
@@ -143,7 +143,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactor()
+        reactor = MemoryReactorClock()
         reactor.listenTCP(443, factory)
 
         token = bytes(uuid4())
@@ -223,7 +223,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactor(), path=serviceaccount.path,
+                MemoryReactorClock(), path=serviceaccount.path,
             ),
             raises(ValueError("No certificate authority certificate found.")),
         )
@@ -254,7 +254,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactor(), path=serviceaccount.path,
+                MemoryReactorClock(), path=serviceaccount.path,
             ),
             raises(ValueError(
                 "Invalid certificate authority certificate found.",

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -35,7 +35,7 @@ from twisted.internet.ssl import (
     CertificateOptions, DN, KeyPair, trustRootFromCertificates,
 )
 from twisted.internet.interfaces import (
-    IReactorSSL, IReactorTCP, IReactorTime, IReactorPluggableNameResolver
+    IReactorSSL, IReactorTCP, IReactorTime, IReactorPluggableNameResolver,
 )
 from twisted.internet.endpoints import SSL4ServerEndpoint
 from twisted.web.client import Agent

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -34,7 +34,7 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.internet.ssl import (
     CertificateOptions, DN, KeyPair, trustRootFromCertificates,
 )
-from twisted.internet.interfaces import IReactorSSL
+from twisted.internet.interfaces import IReactorSSL, IReactorTCP, IReactorTime
 from twisted.internet.endpoints import SSL4ServerEndpoint
 from twisted.web.client import Agent
 from twisted.web.server import Site
@@ -421,7 +421,9 @@ class MemoTests(TestCase):
 
 
 @attr.s
-class Redirectable(proxyForInterface(IReactorSSL)):
+class Redirectable(proxyForInterface(IReactorSSL),
+                   proxyForInterface(IReactorTCP),
+                   proxyForInterface(IReactorTime)):
     """
     An ``IReactorSSL`` which ignores the requested destination and always
     connects to an alternate address instead.
@@ -444,3 +446,11 @@ class Redirectable(proxyForInterface(IReactorSSL)):
         address.
         """
         return self.original.connectSSL(self.host, self.port, *a, **kw)
+
+
+    def connectTCP(self, host, port, *a, **kw):
+        """
+        Establish a TCP connection to the alternate address instead of the given
+        address.
+        """
+        return self.original.connectTCP(self.host, self.port, *a, **kw)

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -34,7 +34,9 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.internet.ssl import (
     CertificateOptions, DN, KeyPair, trustRootFromCertificates,
 )
-from twisted.internet.interfaces import IReactorSSL, IReactorTCP, IReactorTime
+from twisted.internet.interfaces import (
+    IReactorSSL, IReactorTCP, IReactorTime, IReactorPluggableNameResolver
+)
 from twisted.internet.endpoints import SSL4ServerEndpoint
 from twisted.web.client import Agent
 from twisted.web.server import Site
@@ -423,7 +425,8 @@ class MemoTests(TestCase):
 @attr.s
 class Redirectable(proxyForInterface(IReactorSSL),
                    proxyForInterface(IReactorTCP),
-                   proxyForInterface(IReactorTime)):
+                   proxyForInterface(IReactorTime),
+                   proxyForInterface(IReactorPluggableNameResolver)):
     """
     An ``IReactorSSL`` which ignores the requested destination and always
     connects to an alternate address instead.

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -428,7 +428,7 @@ class Redirectable(proxyForInterface(IReactorSSL),
                    proxyForInterface(IReactorTime),
                    proxyForInterface(IReactorPluggableNameResolver)):
     """
-    An ``IReactorSSL`` which ignores the requested destination and always
+    A reactor which ignores the requested destination and always
     connects to an alternate address instead.
 
     :ivar host: The host portion of the alternate address.

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -24,7 +24,7 @@ from eliot.testing import capture_logging
 
 from OpenSSL.crypto import FILETYPE_PEM
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
 from twisted.python.filepath import FilePath
@@ -202,7 +202,7 @@ class ExtraNetworkClientTests(TestCase):
         """
         client = network_kubernetes(
             base_url=URL.fromText(u"http://127.0.0.1/"),
-            agent=Agent(MemoryReactor()),
+            agent=Agent(MemoryReactorClock()),
         ).client()
         client.list(v1.Pod)
 


### PR DESCRIPTION
This is inspired by some of the fixes in https://github.com/LeastAuthority/txkube/pull/135
but only fixes Redirectable.

It seems that in Twisted 17.1.0, there was a lot of refactoring of endpoints, so
new codepaths in Twisted are excercised.

Redirectable.seconds() is needed for this line: https://github.com/twisted/twisted/blob/trunk/src/twisted/internet/task.py#L190

Redirectable.callLater() is needed for this line:
https://github.com/twisted/twisted/blob/trunk/src/twisted/internet/task.py#L276

Redirectable.callTCP() is needed for this line:
https://github.com/twisted/twisted/blob/trunk/src/twisted/internet/endpoints.py#L571