### PR TITLE
Pin iso8601 to 0.1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
         "dev": [
             "testtools",
             "hypothesis",
+            "iso8601==0.1.11",
             "eliot-tree>=17.0.0",
         ],
     },


### PR DESCRIPTION
eliot-tree uses the iso8601.iso8601.Utc symbol which is
gone in iso8601 version 0.1.12