### PR TITLE
Use MemoryReactorClock

### DIFF
--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -32,7 +32,7 @@ from twisted.python.filepath import FilePath
 from twisted.internet.protocol import Factory
 from twisted.web.http_headers import Headers
 from twisted.test.iosim import ConnectionCompleter
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactor
+from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactorClock
 
 from ..testing import TestCase
 
@@ -83,7 +83,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactor()
+        reactor = MemoryReactorClock()
         reactor.listenTCP(80, factory)
 
         t = FilePath(self.useFixture(TempDir()).join(b""))
@@ -143,7 +143,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactor()
+        reactor = MemoryReactorClock()
         reactor.listenTCP(443, factory)
 
         token = bytes(uuid4())
@@ -223,7 +223,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactor(), path=serviceaccount.path,
+                MemoryReactorClock(), path=serviceaccount.path,
             ),
             raises(ValueError("No certificate authority certificate found.")),
         )
@@ -254,7 +254,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactor(), path=serviceaccount.path,
+                MemoryReactorClock(), path=serviceaccount.path,
             ),
             raises(ValueError(
                 "Invalid certificate authority certificate found.",


### PR DESCRIPTION
This doesn't fully fix test_authentication, but it eliminates one error:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/twisted/internet/endpoints.py", line 992, in startConnectionAttempts
    iterateEndpoint.start(self._attemptDelay)
  File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/twisted/internet/task.py", line 190, in start
    self.starttime = self.clock.seconds()
exceptions.AttributeError: 'MemoryReactor' object has no attribute 'seconds'
<not in test>
```
