### PR TITLE
Implement a fake resolver, for compatibility with Twisted 17.1.0 and higher

### DIFF
--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -8,12 +8,16 @@ from datetime import datetime, timedelta
 
 import pem
 
+import attr
+
 from pyrsistent import InvariantException
 
 from fixtures import TempDir
 
-from testtools.matchers import AfterPreprocessing, Equals, Contains, IsInstance, raises
-
+from testtools import ExpectedException
+from testtools.matchers import (
+    AfterPreprocessing, Equals, Contains, IsInstance, raises
+)
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives.hashes import SHA256
@@ -28,7 +32,13 @@ from cryptography.x509 import (
 )
 from cryptography.hazmat.backends import default_backend
 
+from zope.interface import implementer
+
 from twisted.python.filepath import FilePath
+from twisted.internet import defer
+from twisted.internet.address import IPv4Address
+from twisted.internet.error import DNSLookupError
+from twisted.internet.interfaces import IHostResolution, IReactorPluggableNameResolver
 from twisted.internet.protocol import Factory
 from twisted.web.http_headers import Headers
 from twisted.test.iosim import ConnectionCompleter
@@ -68,11 +78,51 @@ b8ravHNjkOR/ez4iyz0H7V84dJzjA1BOoa+Y7mHyhD8S
 -----END CERTIFICATE-----
 """
 
+# Let hostname u"example.invalid" map to an
+# IPv4 address in the TEST-NET range.
+HOST_MAP = {
+    u"example.invalid.": "192.0.2.2"
+}
+
+def create_reactor():
+    """
+    Twisted 17.1.0 and higher requires a reactor which implements
+    ``IReactorPluggableNameResolver``.
+    """
+
+    @implementer(IHostResolution)
+    @attr.s
+    class Resolution(object):
+        name = attr.ib()
+
+    class _FakeResolver(object):
+
+        def resolveHostName(self, resolutionReceiver, hostName, *args,  **kwargs):
+            portNumber = kwargs.pop('portNumber')
+            r = Resolution(name=hostName)
+
+            resolutionReceiver.resolutionBegan(r)
+            if hostName in HOST_MAP:
+                resolutionReceiver.addressResolved(
+                    IPv4Address('TCP', HOST_MAP[hostName], portNumber))
+            resolutionReceiver.resolutionComplete()
+            return r
+
+    @implementer(IReactorPluggableNameResolver)
+    class _ResolvingMemoryClockReactor(MemoryReactorClock):
+        nameResolver = _FakeResolver()
+
+    return _ResolvingMemoryClockReactor()
+
+
+
 class AuthenticateWithServiceAccountTests(TestCase):
     """
     Tests for ``authenticate_with_serviceaccount``.
     """
-    def _authorized_request(self, token, headers):
+    @defer.inlineCallbacks
+    def _authorized_request(self, token, headers,
+                            kubernetes_host=b"example.invalid."):
         """
         Get an agent using ``authenticate_with_serviceaccount`` and issue a
         request with it.
@@ -83,7 +133,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactorClock()
+        reactor = create_reactor()
         reactor.listenTCP(80, factory)
 
         t = FilePath(self.useFixture(TempDir()).join(b""))
@@ -95,7 +145,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.patch(
             os, "environ", {
-                b"KUBERNETES_SERVICE_HOST": b"example.invalid.",
+                b"KUBERNETES_SERVICE_HOST": kubernetes_host,
                 b"KUBERNETES_SERVICE_PORT": b"443",
             },
         )
@@ -103,18 +153,20 @@ class AuthenticateWithServiceAccountTests(TestCase):
         agent = authenticate_with_serviceaccount(
             reactor, path=serviceaccount.path,
         )
-        agent.request(b"GET", b"http://example.invalid.", headers)
 
+        yield agent.request(b"GET", b"http://" + kubernetes_host, headers)
         [(host, port, factory, _, _)] = reactor.tcpClients
 
-        self.expectThat((host, port), Equals((b"example.invalid.", 80)))
+        addr = HOST_MAP.get(kubernetes_host.decode("ascii"), None)
+        self.expectThat((host, port), Equals((addr, 80)))
 
         pump = ConnectionCompleter(reactor).succeedOnce()
         pump.pump()
 
-        return server.data
+        defer.returnValue(server.data)
 
 
+    @defer.inlineCallbacks
     def test_http_bearer_token_authorization(self):
         """
         The ``IAgent`` returned adds an *Authorization* header to each request it
@@ -122,7 +174,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         file.  This works over HTTP.
         """
         token = bytes(uuid4())
-        request_bytes = self._authorized_request(token=token, headers=None)
+        request_bytes = yield self._authorized_request(token=token, headers=None)
 
         # Sure would be nice to have an HTTP parser.
         self.assertThat(
@@ -143,7 +195,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         factory = Factory.forProtocol(lambda: server)
         factory.protocolConnectionMade = None
 
-        reactor = MemoryReactorClock()
+        reactor = create_reactor()
         reactor.listenTCP(443, factory)
 
         token = bytes(uuid4())
@@ -184,6 +236,22 @@ class AuthenticateWithServiceAccountTests(TestCase):
         )
 
 
+    @defer.inlineCallbacks
+    def test_hostname_does_not_resolve(self):
+        """
+        Specifying a hostname which cannot be resolved to an
+        IP address will result in an ``DNSLookupError``.
+        """
+        with ExpectedException(DNSLookupError, "DNS lookup failed: no results "
+                               "for hostname lookup: doesnotresolve."):
+            yield self._authorized_request(
+                token="test",
+                headers=Headers({}),
+                kubernetes_host=b"doesnotresolve"
+            )
+
+
+    @defer.inlineCallbacks
     def test_other_headers_preserved(self):
         """
         Other headers passed to the ``IAgent.request`` implementation are also
@@ -191,7 +259,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         """
         token = bytes(uuid4())
         headers = Headers({u"foo": [u"bar"]})
-        request_bytes = self._authorized_request(token=token, headers=headers)
+        request_bytes = yield self._authorized_request(token=token, headers=headers)
         self.expectThat(
             request_bytes,
             Contains(u"Authorization: Bearer {}".format(token).encode("ascii")),
@@ -223,7 +291,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactorClock(), path=serviceaccount.path,
+                create_reactor(), path=serviceaccount.path,
             ),
             raises(ValueError("No certificate authority certificate found.")),
         )
@@ -254,7 +322,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
 
         self.assertThat(
             lambda: authenticate_with_serviceaccount(
-                MemoryReactorClock(), path=serviceaccount.path,
+                create_reactor(), path=serviceaccount.path,
             ),
             raises(ValueError(
                 "Invalid certificate authority certificate found.",

--- a/src/txkube/testing/__init__.py
+++ b/src/txkube/testing/__init__.py
@@ -5,6 +5,11 @@ __all__ = [
     "strategies",
     "integration",
     "TestCase", "AsynchronousDeferredRunTest",
+    "assertNoResult",
 ]
 
-from ._testcase import TestCase, AsynchronousDeferredRunTest
+from ._testcase import (
+    TestCase,
+    AsynchronousDeferredRunTest,
+    assertNoResult,
+)

--- a/src/txkube/testing/_testcase.py
+++ b/src/txkube/testing/_testcase.py
@@ -10,6 +10,8 @@ from fixtures import CompoundFixture
 from testtools import TestCase as TesttoolsTestCase
 from testtools.twistedsupport import AsynchronousDeferredRunTest
 
+from twisted.python.failure import Failure
+
 from ._eliot import CaptureEliotLogs
 
 
@@ -62,3 +64,17 @@ class TestCase(TesttoolsTestCase):
             # it, Hypothesis can't see which of its example runs caused
             # problems.
             self.fail("expectation failed")
+
+
+
+def assertNoResult(case, d):
+    """
+    Assert that ``d`` does not have a result at this point.
+    """
+    result = []
+    d.addBoth(result.append)
+    if result:
+        if isinstance(result[0], Failure):
+            result[0].raiseException()
+        else:
+            case.fail("Got {} but expected no result".format(result[0]))


### PR DESCRIPTION
This is a forward port of part of the patch in https://github.com/LeastAuthority/txkube/pull/135 .

I couldn't find any existing test classes in Twisted which worked to get this test working.