### PR TITLE
Use Twisted 17.9.0 or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         "incremental",
         # See https://github.com/twisted/treq/issues/167
         # And https://twistedmatrix.com/trac/ticket/9032
-        "twisted[tls]!=17.1.0",
+        "twisted[tls]>=17.9.0",
         "pem",
         "eliot",
         "python-dateutil",


### PR DESCRIPTION
Some backwards incompatible changes have been done with respect to endpoints and SSL, so target the newer version of Twisted.

See:
https://github.com/twisted/twisted/commit/cd75dd82f41b834ec8d53827932cf566116e3c0d
https://github.com/twisted/twisted/pull/611
https://github.com/twisted/twisted/pull/624