### PR TITLE
We must pass method of type unicode, not bytes.

### DIFF
--- a/src/txkube/_network.py
+++ b/src/txkube/_network.py
@@ -137,7 +137,7 @@ class _NetworkClient(object):
     def _request(self, method, url, headers=None, bodyProducer=None):
         action = start_action(
             action_type=u"network-client:request",
-            method=method,
+            method=method.decode("ascii"),
             url=url.asText(),
         )
         with action.context():


### PR DESCRIPTION
This eliminates json decode errors on Python 3.