### PR TITLE
Fix pclass() on Python 3 by explicitly setting value of __hash__.

### DIFF
--- a/src/txkube/_swagger.py
+++ b/src/txkube/_swagger.py
@@ -780,6 +780,7 @@ class _ClassModel(PClass):
         content["serialize"] = _serialize_with_omit
         content["__new__"] = discard_constant_fields
         content["__cmp__"] = compare_pclass
+        content["__hash__"] = PClass.__hash__
         huh = type(nativeString(self.name), bases + (PClass,), content)
         return huh
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] There is an associated issue.
      [Create a new one](https://github.com/LeastAuthority/txkube/issues/new) if necessary.
      Link to it below.
* [x] I have created a [newsfragment](http://towncrier.readthedocs.io/en/actual-freaking-docs/quickstart.html#creating-news-fragments) in src/txkube/newsfragments/
* [x] I have updated the automated tests.

##

Fixes #185 


Without this, `__hash__` is `None`, and we get 'unhashable type' errors.