### PR TITLE
Use unicode os.environ on Python 3, and bytes os.environ on Python 2.

### DIFF
--- a/src/txkube/_authentication.py
+++ b/src/txkube/_authentication.py
@@ -244,7 +244,10 @@ def https_policy_from_config(config):
         signed by the certificate authority certificate associated with the
         active context's cluster.
     """
-    base_url = URL.fromText(config.cluster["server"].decode("ascii"))
+    server = config.cluster["server"]
+    if isinstance(server, bytes):
+        server = server.decode("ascii")
+    base_url = URL.fromText(server)
 
     ca_certs = pem.parse(config.cluster["certificate-authority"].bytes())
     if not ca_certs:

--- a/src/txkube/test/_compat.py
+++ b/src/txkube/test/_compat.py
@@ -1,0 +1,21 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Helpers for Python 2/3 compatibility.
+"""
+
+from twisted.python.compat import _PY3
+
+def encode_environ(env):
+    """
+    Convert a ``dict`` of ``unicode`` keys and values to ``bytes`` on Python 2,
+    but return the ``dict`` unmodified on Python 3.
+    """
+    if _PY3:
+        return env
+    else:
+        bytes_env = {}
+        for key in env:
+            bytes_env[key.encode("ascii")] = env[key].encode("ascii")
+        return bytes_env

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -29,6 +29,7 @@ from cryptography.hazmat.backends import default_backend
 
 from zope.interface import implementer
 
+from twisted.python.compat import unicode
 from twisted.python.filepath import FilePath
 from twisted.internet.address import IPv4Address
 from twisted.internet.error import DNSLookupError
@@ -184,7 +185,9 @@ class AuthenticateWithServiceAccountTests(TestCase):
         issues.  The header includes the bearer token from the service account
         file.
         """
-        token = bytes(uuid4())
+        token = str(uuid4())
+        if isinstance(token, unicode):
+            token = token.encode("ascii")
         request_bytes = self._authorized_request(token=token, headers=None)
 
         # Sure would be nice to have an HTTP parser.
@@ -213,7 +216,9 @@ class AuthenticateWithServiceAccountTests(TestCase):
         Other headers passed to the ``IAgent.request`` implementation are also
         sent in the request.
         """
-        token = bytes(uuid4())
+        token = str(uuid4())
+        if isinstance(token, unicode):
+            token = token.encode("ascii")
         headers = Headers({u"foo": [u"bar"]})
         request_bytes = self._authorized_request(token=token, headers=headers)
         self.expectThat(

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -289,7 +289,7 @@ class HTTPSPolicyFromConfigTests(TestCase):
         })
         self.patch(os, "environ", environ)
 
-        config = KubeConfig.from_service_account(path=serviceaccount.path)
+        config = KubeConfig.from_service_account(path=serviceaccount.asTextMode().path)
         self.assertThat(
             lambda: https_policy_from_config(config),
             raises(ValueError("No certificate authority certificate found.")),

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -163,7 +163,7 @@ class AuthenticateWithServiceAccountTests(TestCase):
         self.patch(os, "environ", environ)
 
         agent = authenticate_with_serviceaccount(
-            reactor, path=serviceaccount.path,
+            reactor, path=serviceaccount.asTextMode().path,
         )
 
         d = agent.request(b"GET", b"http://" + kubernetes_host, headers)
@@ -324,7 +324,7 @@ class HTTPSPolicyFromConfigTests(TestCase):
         })
         self.patch(os, "environ", environ)
 
-        config = KubeConfig.from_service_account(path=serviceaccount.path)
+        config = KubeConfig.from_service_account(path=serviceaccount.asTextMode().path)
         self.assertThat(
             lambda: https_policy_from_config(config),
             raises(ValueError(

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -254,7 +254,7 @@ class HTTPSPolicyFromConfigTests(TestCase):
         })
         self.patch(os, "environ", environ)
 
-        config = KubeConfig.from_service_account(path=serviceaccount.path)
+        config = KubeConfig.from_service_account(path=serviceaccount.asTextMode().path)
 
         policy = https_policy_from_config(config)
         self.expectThat(

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -146,7 +146,8 @@ class AuthenticateWithServiceAccountTests(TestCase):
         reactor = create_reactor()
         reactor.listenTCP(80, factory)
 
-        t = FilePath(self.useFixture(TempDir()).join(b""))
+        t = FilePath(self.useFixture(TempDir()).path)
+        t = t.asBytesMode()
         serviceaccount = t.child(b"serviceaccount")
         serviceaccount.makedirs()
 
@@ -238,7 +239,8 @@ class HTTPSPolicyFromConfigTests(TestCase):
         *KUBERNETES_...* environment variables to identify the address of the
         server.
         """
-        t = FilePath(self.useFixture(TempDir()).join(b""))
+        t = FilePath(self.useFixture(TempDir()).path)
+        t = t.asBytesMode()
         serviceaccount = t.child(b"serviceaccount")
         serviceaccount.makedirs()
 
@@ -273,7 +275,8 @@ class HTTPSPolicyFromConfigTests(TestCase):
         If no CA certificate is found in the service account directory,
         ``https_policy_from_config`` raises ``ValueError``.
         """
-        t = FilePath(self.useFixture(TempDir()).join(b""))
+        t = FilePath(self.useFixture(TempDir()).path)
+        t = t.asBytesMode()
         serviceaccount = t.child(b"serviceaccount")
         serviceaccount.makedirs()
 
@@ -298,7 +301,8 @@ class HTTPSPolicyFromConfigTests(TestCase):
         If no CA certificate is found in the service account directory,
         ``https_policy_from_config`` raises ``ValueError``.
         """
-        t = FilePath(self.useFixture(TempDir()).join(b""))
+        t = FilePath(self.useFixture(TempDir()).path)
+        t = t.asBytesMode()
         serviceaccount = t.child(b"serviceaccount")
         serviceaccount.makedirs()
 


### PR DESCRIPTION
Fixes https://github.com/LeastAuthority/txkube/issues/178