### PR TITLE
Import twisted.python.compat to facilitate Python 3.

### DIFF
--- a/src/txkube/test/test_swagger.py
+++ b/src/txkube/test/test_swagger.py
@@ -17,6 +17,7 @@ from pyrsistent import (
     PTypeError, PClass, freeze,
 )
 
+from twisted.python.compat import long, unicode
 from twisted.python.filepath import FilePath
 
 from testtools.matchers import (
@@ -383,7 +384,7 @@ class SwaggerTests(TestCase):
         self.expectThat(Type(s=u"foo").s, Equals(u"foo"))
         self.expectThat(Type(s=u"50").s, Equals(u"50"))
         self.expectThat(Type(s=50).s, Equals(50))
-        self.expectThat(Type(s=50L).s, Equals(50))
+        self.expectThat(Type(s=long(50)).s, Equals(50))
 
 
     def test_object(self):


### PR DESCRIPTION
Use long() instead of long literal to fix test on Python 3.