### PR TITLE
Fix some tests in test_network on Python 3

### DIFF
--- a/src/txkube/_network.py
+++ b/src/txkube/_network.py
@@ -158,7 +158,10 @@ def network_kubernetes_from_context(
     cluster = config.clusters[context[u"cluster"]]
     user = config.users[context[u"user"]]
 
-    base_url = URL.fromText(cluster[u"server"].decode("ascii"))
+    if isinstance(cluster[u"server"], bytes):
+        base_url = URL.fromText(cluster[u"server"].decode("ascii"))
+    else:
+        base_url = URL.fromText(cluster[u"server"])
     [ca_cert] = parse(cluster[u"certificate-authority"].bytes())
 
     client_chain = parse(user[u"client-certificate"].bytes())

--- a/src/txkube/_network.py
+++ b/src/txkube/_network.py
@@ -215,7 +215,7 @@ class _NetworkClient(object):
     def _request(self, method, url, headers=None, bodyProducer=None):
         action = start_action(
             action_type=u"network-client:request",
-            method=method,
+            method=method.decode("ascii"),
             url=url.asText(),
         )
         with action.context():

--- a/src/txkube/_swagger.py
+++ b/src/txkube/_swagger.py
@@ -585,7 +585,10 @@ def _parse_iso8601(text):
 
 
 def _isoformat(format, v):
-    return v.isoformat().decode("ascii")
+    v_isoformat = v.isoformat()
+    if isinstance(v_isoformat, bytes):
+        v_isoformat = v_isoformat.decode("ascii")
+    return v_isoformat
 
 
 

--- a/src/txkube/test/test_network.py
+++ b/src/txkube/test/test_network.py
@@ -42,6 +42,7 @@ from cryptography.hazmat.backends import default_backend
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
+from twisted.python.compat import unicode
 from twisted.python.filepath import FilePath
 from twisted.python.url import URL
 from twisted.python.components import proxyForInterface
@@ -463,8 +464,8 @@ class NetworkKubernetesFromContextTests(TwistedTestCase):
 
         :return FilePath: The path to the written configuration file.
         """
-        config = FilePath(self.mktemp())
-        config.setContent(safe_dump({
+        config_file = FilePath(self.mktemp())
+        config = safe_dump({
             "apiVersion": "v1",
             "kind": "Config",
             "contexts": [
@@ -494,8 +495,11 @@ class NetworkKubernetesFromContextTests(TwistedTestCase):
                     },
                 },
             ],
-        }))
-        return config
+        })
+        if isinstance(config, unicode):
+            config = config.encode("ascii")
+        config_file.setContent(config)
+        return config_file
 
 
     def test_kubeconfig_environment(self):

--- a/src/txkube/test/test_swagger.py
+++ b/src/txkube/test/test_swagger.py
@@ -353,15 +353,18 @@ class SwaggerTests(TestCase):
             raises_exception(CheckedValueTypeError),
         )
         now = datetime.utcnow()
+        now_isoformat = now.isoformat()
+        if isinstance(now_isoformat, bytes):
+            now_isoformat = now_isoformat.decode("ascii")
         self.expectThat(Type(s=now).s, Equals(now))
-        self.expectThat(Type(s=now.isoformat().decode("ascii")).s, Equals(now))
+        self.expectThat(Type(s=now_isoformat).s, Equals(now))
 
         # string / date-time fields serialize back to an ISO8601 format
         # string.
         serialized = Type(s=now).serialize()
         self.expectThat(
             serialized,
-            Equals({u"s": now.isoformat().decode("ascii")}),
+            Equals({u"s": now_isoformat}),
         )
         # Thanks for making bytes and unicode compare equal, Python.
         self.expectThat(serialized[u"s"], IsInstance(unicode))

--- a/src/txkube/testing/strategies.py
+++ b/src/txkube/testing/strategies.py
@@ -47,8 +47,13 @@ def dns_labels():
     # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md
     # https://kubernetes.io/docs/user-guide/identifiers/#names
     # https://www.ietf.org/rfc/rfc1035.txt
-    letter = ascii_lowercase.decode("ascii")
-    letter_digit = letter + digits.decode("ascii")
+    letter = ascii_lowercase
+    numbers = digits
+    if isinstance(letter, bytes):
+        letter = letter.decode("ascii")
+    if isinstance(numbers, bytes):
+        numbers = numbers.decode("ascii")
+    letter_digit = letter + numbers
     letter_digit_hyphen = letter_digit + u"-"
     variations = [
         # Could be just one character long


### PR DESCRIPTION
With this patch, 8 out of 9 test_network tests pass on Python 3.
The one failing test `txkube.test.test_network.NetworkKubernetesFromContextTests.test_client_chain_certificate`
seems to be due to a bug in twisted.web on Python 3.