### PR TITLE
Run codecov step on Python 3, even though Python 3 tests are still failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,12 @@ cache:
     - "$HOME/.cache/pip"
 
 install:
-  - "pip install --upgrade pip setuptools wheel coverage codecov pyflakes"
-  - "pip install .[dev]"
+  - "python -m pip install --upgrade pip setuptools wheel coverage codecov pyflakes"
+  - "python -m pip install .[dev]"
 
 script:
-  - "pyflakes src"
+  - "python -m pyflakes src"
   - "python -Wdefault::DeprecationWarning -m coverage run --rcfile=${PWD}/.coveragerc -m twisted.trial txkube"
   # See .coveragerc for an explanation of this step.
   - "python -m coverage combine .coverage"
-
-after_success:
-  - "codecov"
+  - "python -m codecov"


### PR DESCRIPTION
This let's us gradually increase coverage reports over Python 3-specific code in txkube.