### PR TITLE
Always run codecov step, even if script section fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ script:
   # See .coveragerc for an explanation of this step.
   - "python -m coverage combine .coverage"
 
-after_success:
+after_script:
   - "codecov"


### PR DESCRIPTION
This will allow uploading coverage results for Python 3,
even though not all the tests pass yet on Python 3.