### PR TITLE
creatorForNetloc() must be supplied bytes for the hostname.

### DIFF
--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -360,7 +360,8 @@ class ClientCertificatePolicyForHTTPSTests(TestCase):
         )
         creator = policy.creatorForNetloc(
             host_used.encode("ascii"),
-            port_used)
+            port_used,
+        )
         verifyObject(IOpenSSLClientConnectionCreator, creator)
 
 

--- a/src/txkube/test/test_authentication.py
+++ b/src/txkube/test/test_authentication.py
@@ -358,7 +358,9 @@ class ClientCertificatePolicyForHTTPSTests(TestCase):
                 netloc: cert,
             },
         )
-        creator = policy.creatorForNetloc(host_used, port_used)
+        creator = policy.creatorForNetloc(
+            host_used.encode("ascii"),
+            port_used)
         verifyObject(IOpenSSLClientConnectionCreator, creator)
 
 


### PR DESCRIPTION
In `test_creatorForNetLoc_interface()`, we call `NetLocation()`, which takes unicode for the hostname.

Subsequently we call `creatorForNetloc()`, which takes `bytes` for the hostname.

The input parameter `host_known` is supplied by `dns_subdomains()`.
The input parameter `host_used` is supplied by `dns_subdomains()`.

`dns_subdomains()` is supplying `unicode` on Python 3 **and** Python 2.  So we need to make sure that we are really passing `bytes` to `creatorForNetloc()`.

Fixes #177 