### PR TITLE
Replace deprecated functions in eliottree with newer functions

### DIFF
--- a/src/txkube/testing/_eliot.py
+++ b/src/txkube/testing/_eliot.py
@@ -32,7 +32,7 @@ def _eliottree(logs):
     render_tasks(
         write=out.write,
         tasks=tasks,
-        field_limit=0
+        field_limit=0,
     )
     return out.getvalue()
 

--- a/src/txkube/testing/_eliot.py
+++ b/src/txkube/testing/_eliot.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 from fixtures import Fixture
 
-from eliot import add_destination, remove_destination
+from eliot import add_destinations, remove_destination
 from eliottree import Tree, render_task_nodes
 
 from testtools.content import Content
@@ -54,7 +54,7 @@ class CaptureEliotLogs(Fixture):
     # otherwise expect are private.
     def _setUp(self):
         self.logs = []
-        add_destination(self.logs.append)
+        add_destinations(self.logs.append)
         self.addCleanup(lambda: remove_destination(self.logs.append))
         self.addDetail(
             self.LOG_DETAIL_NAME,

--- a/src/txkube/testing/_eliot.py
+++ b/src/txkube/testing/_eliot.py
@@ -6,12 +6,12 @@ Integration between Eliot, eliottree, and testtools to provide easily
 readable Eliot logs for failing tests.
 """
 
-from io import BytesIO
+from io import StringIO
 
 from fixtures import Fixture
 
 from eliot import add_destinations, remove_destination
-from eliottree import Tree, render_task_nodes
+from eliottree import tasks_from_iterable, render_tasks
 
 from testtools.content import Content
 from testtools.content_type import UTF8_TEXT
@@ -26,15 +26,13 @@ def _eliottree(logs):
 
     :return bytes: The rendered string.
     """
-    tree = Tree()
-    tree.merge_tasks(logs)
-    nodes = tree.nodes()
+    tasks = tasks_from_iterable(logs)
 
-    out = BytesIO()
-    render_task_nodes(
+    out = StringIO()
+    render_tasks(
         write=out.write,
-        nodes=nodes,
-        field_limit=0,
+        tasks=tasks,
+        field_limit=0
     )
     return out.getvalue()
 

--- a/src/txkube/testing/_eliot.py
+++ b/src/txkube/testing/_eliot.py
@@ -24,7 +24,7 @@ def _eliottree(logs):
     :param list[dict] logs: The Eliot log events to render.  These should be
         dicts like those passed to an Eliot destination.
 
-    :return bytes: The rendered string.
+    :return unicode: The rendered string.
     """
     tasks = tasks_from_iterable(logs)
 

--- a/src/txkube/testing/test/test_eliot.py
+++ b/src/txkube/testing/test/test_eliot.py
@@ -34,5 +34,5 @@ class EliotTreeTests(TestCase):
         # I'm using eliot-tree!  So this assertion is sort of lame.
         self.assertThat(
             _eliottree(events),
-            Contains(u"foo@1/started"),
+            Contains(u"foo/1 \u21d2 started"),
         )

--- a/src/txkube/testing/test/test_eliot.py
+++ b/src/txkube/testing/test/test_eliot.py
@@ -33,6 +33,6 @@ class EliotTreeTests(TestCase):
         # I don't know exactly what the tree rendering looks like.  That's why
         # I'm using eliot-tree!  So this assertion is sort of lame.
         self.assertThat(
-            _eliottree(events).decode("utf-8"),
+            _eliottree(events),
             Contains(u"foo@1/started"),
         )

--- a/src/txkube/testing/test/test_eliot.py
+++ b/src/txkube/testing/test/test_eliot.py
@@ -5,7 +5,7 @@
 Tests for ``txkube.testing._eliot``.
 """
 
-from eliot import start_action, add_destination, remove_destination
+from eliot import start_action, add_destinations, remove_destination
 
 from testtools.matchers import Contains
 
@@ -24,7 +24,7 @@ class EliotTreeTests(TestCase):
         Eliot actions and messages.
         """
         events = []
-        add_destination(events.append)
+        add_destinations(events.append)
         self.addCleanup(lambda: remove_destination(events.append))
 
         with start_action(action_type=u"foo"):


### PR DESCRIPTION
I saw these deprecation warnings when running the txkube tests:

```
/Users/crodrigues/txkube/src/txkube/testing/test/test_eliot.py:27: DeprecationWarning: add_destination is deprecated since 1.1.0. Use add_destinations instead.
/Users/crodrigues/txkube/src/txkube/testing/_eliot.py:29: DeprecationWarning: Tree is deprecated, use eliottree.tasks_from_iterable instead
/Users/crodrigues/txkube/src/txkube/testing/_eliot.py:37: DeprecationWarning: render_task_nodes is deprecated, use eliottree.render_tasks instead
```

so took a stab at using newer functions.

Fixes https://github.com/LeastAuthority/txkube/issues/179